### PR TITLE
Fix line 58: Use GitHub API to reliably resolve latest release tag

### DIFF
--- a/public/windows.ps1
+++ b/public/windows.ps1
@@ -52,10 +52,15 @@ $arch = switch -Wildcard ((Get-CimInstance Win32_Processor | Select-Object -Firs
   default { 'amd64' }
 }
 
-$latest = Invoke-WebRequest -UseBasicParsing -MaximumRedirection 5 -Uri "https://github.com/$repo/releases/latest"
-$tag = ($latest.BaseResponse.ResponseUri.AbsolutePath -replace '.*/tag/','').Trim('/')
-if (-not $tag -or $tag -match 'releases/latest') {
-  Write-Error 'Failed to resolve latest noctis-host release tag.'
+# Use GitHub API to get the latest release tag reliably
+try {
+  $latestRelease = Invoke-WebRequest -UseBasicParsing -Uri "https://api.github.com/repos/$repo/releases/latest" | ConvertFrom-Json
+  $tag = $latestRelease.tag_name
+  if (-not $tag) {
+    throw "No tag_name in response"
+  }
+} catch {
+  Write-Error "Failed to resolve latest noctis-host release tag: $($_.Exception.Message)"
   exit 1
 }
 


### PR DESCRIPTION
## Problem
Line 58 was failing when trying to extract the release tag from the HTTP redirect URI. The original approach relied on parsing `BaseResponse.ResponseUri.AbsolutePath`, which is fragile and fails in various environments.

## Solution
Replaced the fragile redirect parsing with a direct call to the GitHub API:
- Uses `https://api.github.com/repos/c0nn3ct-xyz/noctis-host/releases/latest`
- Parses the JSON response to extract `tag_name` directly
- Includes proper error handling with informative error messages
- More reliable and maintainable across different environments

## Testing
✅ Tested successfully with the extension ID and verified that:
- The script resolves the latest release tag correctly
- All cores (sing-box, xray, mihomo) download and install properly
- The helper registers for all browsers without errors

## Changes
- Replaced HTTP redirect parsing with GitHub API call
- Added try-catch error handling
- Improved error messages to aid debugging